### PR TITLE
Correct formatting error that ignored plugin's option to enable itself

### DIFF
--- a/wp-cron-control.php
+++ b/wp-cron-control.php
@@ -95,8 +95,8 @@ class WP_Cron_Control {
 		self::instance()->settings_page_name = sprintf( __( '%s Settings', 'wp-cron-control' ), self::instance()->plugin_name );
 
 		if ( 1 == self::instance()->settings['enable'] ) {
+			self::instance()->prepare();
 		}
-		self::instance()->prepare();
 	}
 
 	/*


### PR DESCRIPTION
This bug has existed since the beginning of time: https://plugins.trac.wordpress.org/changeset/418031. In production, however, this has been fixed without any negative repercussions.
